### PR TITLE
Fix some HTML5 syntax errors

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <title>
       PDF to Text - pdftotext.org
     </title>
-    <meta name=viewport content=width=device-width,initial-scale=1>
+    <meta name=viewport content="width=device-width,initial-scale=1">
     <link href=bootstrap.min.css rel=stylesheet>
     <link href=material.min.css rel=stylesheet>
     <link href=material-wfont.min.css rel=stylesheet>
@@ -119,14 +119,13 @@
             The conversion is done locally in your browser &ndash;
             you can even convert when you are offline!
           </p>
-          </p>
+          <p>
             There is no need for any registration or sign-up,
             and the service will always be free to use.
           </p>
         </div>
       </div>
     </div>
-  </div>
 
   <footer>
     <div class=container>


### PR DESCRIPTION
Reference for the syntax error in the meta tag:
http://www.w3.org/TR/html-markup/syntax.html#syntax-attribute-value_xref3

>  an unquoted attribute value (...) must not contain any `"`, `'`, `=`, `>`, `<`, or ```, characters
